### PR TITLE
Prevent app crash due to passing empty string to folder name in MainActivity dialogue view

### DIFF
--- a/app/src/main/java/com/quchen/flashcard/MainActivity.java
+++ b/app/src/main/java/com/quchen/flashcard/MainActivity.java
@@ -16,6 +16,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -80,9 +81,13 @@ public class MainActivity extends AppCompatActivity {
         alert.setPositiveButton(R.string.createFolderYesOption, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
                 String folderName = edittext.getText().toString();
-                File folder = new File(App.getListRootDir(), folderName);
-                folder.mkdir();
-                folderAdapter.add(folderName);
+                if (folderName.equals("")) {
+                    Toast.makeText(MainActivity.this, "Folder name can't be empty!", Toast.LENGTH_SHORT).show();
+                } else {
+                    File folder = new File(App.getListRootDir(), folderName);
+                    folder.mkdir();
+                    folderAdapter.add(folderName);
+                }
             }
         });
 


### PR DESCRIPTION
I noticed  that, if we don't type any text in create new dialog `edittext` in `MainActivity.java,` it leads to app crash. It is fixed by adding an `if statement` to check whether the string is empty or not.

I also tried to show `edittext.setError("Message")` to let the user know they want to insert any name for the folder to be created, but since this is dialog view, it is dismissing once we click 'create folder' button. 

The code might wan't to be edited.